### PR TITLE
chore: move from yarn prepublish to yarn prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "version": ">0.2"
   },
   "scripts": {
-    "build": "yarn prepublish",
+    "build": "yarn prepack",
     "generate-types": "graphql-codegen --config codegen.yml",
     "prepare": "npx husky install && shx rm -rf .git/hooks && shx ln -s ../.husky .git/hooks",
-    "prepublish": "rm -rf dist && yarn generate-types && tsc && yarn cpx 'src/**/*.graphql' dist",
+    "prepack": "rm -rf dist && yarn generate-types && tsc && yarn cpx 'src/**/*.graphql' dist",
     "test": "NODE_ENV=test jest ./tests",
     "lint": "eslint --config .eslintrc.json --ext .js,.ts ./",
     "lint:fix": "eslint --fix --config .eslintrc.json --ext .js,.ts ./",


### PR DESCRIPTION
Move build from `prepublish` to `prepack` in keeping with Yarn best practices and Github Action requirements